### PR TITLE
riscv64,mmu: avoid updating PTE.A/D in so-file

### DIFF
--- a/src/isa/riscv64/mmu.c
+++ b/src/isa/riscv64/mmu.c
@@ -103,12 +103,14 @@ static paddr_t ptw(vaddr_t vaddr, int type) {
     pg_base = (pg_base & ~pg_mask) | (vaddr & pg_mask & ~PGMASK);
   }
 
+#if !_SHARE
   bool is_write = (type == MEM_TYPE_WRITE);
   if (!pte.a || (!pte.d && is_write)) {
     pte.a = true;
     pte.d |= is_write;
     paddr_write(p_pte, pte.val, PTE_SIZE);
   }
+#endif
 
   return pg_base | MEM_RET_OK;
 }


### PR DESCRIPTION
* see issue #14